### PR TITLE
Fix: typo in default options

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const nunjucks = require("nunjucks");
 const MjmlPlugin = (eleventyConfig, suppliedOptions) => {
   const defaultOptions = {
     preprocessWithNunjucks: false,
-    nnjucksFilters: {},
+    nunjucksFilters: {},
   };
 
   const options = lodashMerge(defaultOptions, suppliedOptions);


### PR DESCRIPTION
This typo causes the plugin to fail